### PR TITLE
Blackduck: Automated PR: Update org.hsqldb:hsqldb:2.3.4 to 2.7.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,7 +157,7 @@
 		<dependency>
 			<groupId>org.hsqldb</groupId>
 			<artifactId>hsqldb</artifactId>
-			<version>2.3.4</version>
+			<version>2.7.4</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-dbcp</groupId>


### PR DESCRIPTION
## Vulnerabilities associated with org.hsqldb:hsqldb:2.3.4
[BDSA-2022-3330](https://openhub.net/vulnerabilities/bdsa/BDSA-2022-3330) *(HIGH)*: HyperSQL DataBase is vulnerable to remote code execution (RCE) due to improper input validation thus allowing unsafe reflection. An authenticated attacker could exploit this by supplying a crafted input to potentially execute code on the application.

[Click Here To See More Details On Server](https://saastest.app.blackduck.com/api/projects/ffd5904f-a56f-4229-b08c-ad6316c0fe86/versions/aa0e0b36-27a4-465a-ab5d-e138bf061f16/vulnerability-bom?selectedItem=f28e29c2-ef79-4f9e-87ba-2bfb355c76b0)